### PR TITLE
Add release/manual GitHub Actions pipeline for tests and Sphinx docs deployment

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,0 +1,77 @@
+name: Release QA and Docs
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Run test suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[docs] pytest
+
+      - name: Run tests
+        run: pytest -q
+
+  build-docs:
+    name: Build Sphinx docs
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install doc dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[docs]
+
+      - name: Build HTML docs
+        run: sphinx-build -W -b html docs docs/_build/html
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy-docs:
+    name: Deploy docs to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build-docs
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Ensure tests run and Sphinx docs are built and deployed only on published releases or when manually triggered, rather than on every push or PR.
- Provide a single CI workflow that gates docs deployment on a successful test run and produces a Pages artifact for deployment.

### Description
- Add a new workflow file at `.github/workflows/release-docs.yml` that is triggered on `release` (types: `published`) and `workflow_dispatch` only.
- Add a `test` job that checks out the repo, sets up Python 3.11, installs project docs extras and `pytest` via `pip install -e .[docs] pytest`, and runs `pytest -q`.
- Add a `build-docs` job that runs after `test`, installs docs dependencies, runs `sphinx-build -W -b html docs docs/_build/html`, configures Pages with `actions/configure-pages@v5`, and uploads the built HTML via `actions/upload-pages-artifact@v3`.
- Add a `deploy-docs` job that runs after `build-docs` and deploys the uploaded artifact to GitHub Pages using `actions/deploy-pages@v4` with `pages: write` and `id-token: write` permissions and the `github-pages` environment.

### Testing
- Ran `PYTHONPATH=. pytest -q` locally and the test suite completed successfully (all tests passed).
- Attempted `python -m pip install --upgrade pip && pip install -e .[docs] pytest` to validate the workflow install step but it failed due to network/proxy restrictions while resolving build dependencies (error resolving `setuptools>=68`).
- Attempted `PYTHONPATH=. sphinx-build -W -b html docs docs/_build/html` but it failed because `sphinx-build` is not available in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f790fdbb88322814d17a2541ce0c0)