### PR TITLE
Fix Sphinx docs warnings causing GitHub deployment failures

### DIFF
--- a/docs/_static/.gitkeep
+++ b/docs/_static/.gitkeep
@@ -1,0 +1,1 @@
+# Keep Sphinx static assets directory in version control.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,13 +1,6 @@
 API Reference
 =============
 
-Package exports
----------------
-
-.. automodule:: colophon
-   :members:
-   :undoc-members:
-
 Models
 ------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -255,7 +255,7 @@ Use the imported graph directly in manuscript generation:
      --report build/manuscript_from_notes_diagnostics.json
 
 Notes source formatting guide
-----------------------------
+-----------------------------
 
 Obsidian:
 


### PR DESCRIPTION
### Motivation
- CI Sphinx builds were failing because duplicate cross-reference targets were created by documenting both the package re-exports and the original modules, and the docs static path and an RST underline were also emitting warnings.

### Description
- Remove the top-level `.. automodule:: colophon` package export block from `docs/api.rst` to avoid duplicate Python cross-reference targets (e.g., `Figure`, `Chapter`, `GapRequest`, `CoordinationMessage`).
- Fix the heading underline length for `Notes source formatting guide` in `docs/usage.rst` to correct title formatting.
- Add `docs/_static/.gitkeep` so the `html_static_path = ["_static"]` directory exists in CI and does not produce a missing-static-path warning.

### Testing
- Ran `python -m sphinx -E -b html -W docs docs/_build/html` and the build now succeeds with warnings treated as errors (HTML output generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f805a8db88322b6e1fe1a20a8df89)